### PR TITLE
don't redirect with secret as get parameter in url

### DIFF
--- a/Classes/Controller/OnetimesecretController.php
+++ b/Classes/Controller/OnetimesecretController.php
@@ -159,7 +159,8 @@ class OnetimesecretController extends ActionController
                     $this->onetimesecretRepository->remove($onetimesecret);
                     $this->persistenceManager->persistAll();
 
-                    $this->redirect('success', null, null, compact('secret'));
+                    $this->view->setTemplate('Onetimesecret/Success');
+                    $this->view->assign('secret', $secret);
 
                 } else {
                     $this->onetimesecretRepository->remove($onetimesecret);


### PR DESCRIPTION
Secret is visible in url as get parameter -> tx_onetimesecret_onetimesecret[secret]
Example: &tx_onetimesecret_onetimesecret%5Bsecret%5D=testSecret&cHash